### PR TITLE
Add MovePreprocessor

### DIFF
--- a/helper-js/board.js
+++ b/helper-js/board.js
@@ -65,9 +65,36 @@ export class Position {
         return ['x', 'y'].includes(this.column);
     }
 
+    isWithinBounds() {
+        // TEMP has no row position, so just return true
+        if ( this.isTemp() ) return true;
+
+        // only valid 'z' position is 'z1'
+        if ( this.column == 'z' ) return this.row == 1;
+
+        // For jail row must be 1 or 2
+        if ( this.isJail() ) return this.row == 1 || this.row == 2;
+        
+        // If this code is reached the piece must be on the board
+        const { vertical, horizontal } = this.coords;
+        if ( vertical < 1 || vertical > 8 ) return false;
+        if ( horizontal < 1 || horizontal > 8 ) return false;
+        return true;
+    }
+
     // Defining toString allows this to be used as the index for boardLayout
     toString() {
         return this.id;
+    }
+
+    // Adds an array of [vertical, horizontal] (called "vector") to this
+    // position, returning a new position as the result.
+    plus (vector) {
+        const coords = this.coords;
+        return new Position({
+            vertical: coords.vertical + vector[0],
+            horizontal: coords.horizontal + vector[1]
+        });
     }
 
     static toID = [

--- a/helper-js/moves.js
+++ b/helper-js/moves.js
@@ -1,0 +1,47 @@
+import { Position } from "./board.js";
+
+export class DefaultMoveSpec {
+    constructor (spec) {
+        this.spec = spec;
+    }
+    maybeOutput ({ piece, output }) {
+        const refPos = piece.position;
+        const vector = [...this.spec.pos];
+
+        // Flip position change for black pieces
+        if ( ! piece.isWhite ) vector[0] *= -1;
+
+        // Add position change to reference position
+        const pos = refPos.plus(vector);
+
+        // Do not output if this position is off the board
+        // TODO: have board class implement this instead
+        if ( ! pos.isWithinBounds() ) return;
+
+        output.push({ pos: pos.id, conditions: this.spec.conditions });
+    }
+}
+
+export class MovePreprocessor {
+    constructor (piece, moves) {
+        this.piece = piece;
+        this.moves = moves;
+    }
+
+    static moveSpecTypes = {
+        place: DefaultMoveSpec
+    };
+
+    getMoves() {
+        const piece = this.piece;
+
+        const output = [];
+
+        for ( let move of this.moves ) {
+            move = new MovePreprocessor.moveSpecTypes[move.type || 'place'](move);
+            move.maybeOutput({ piece, output });
+        }
+
+        return output;
+    }
+}

--- a/pieces-js/Fish.js
+++ b/pieces-js/Fish.js
@@ -15,26 +15,14 @@ export class Fish extends Piece {
         }
     }
 
-    getMoves(){
-        let {vertical, horizontal} = getVerticalAndHorizontal(this.position)
-            
-        let output = []
-
-        if (horizontal + 1 < 9) output.push( {pos: verticalAndHorizontalToID(vertical, horizontal+1), conditions: [noPiece]} )
-        if (horizontal - 1 > 0) output.push( {pos: verticalAndHorizontalToID(vertical, horizontal-1), conditions: [noPiece]} )
-        
-        if (this.isWhite){
-            if (vertical + 1 < 9) output.push( {pos: verticalAndHorizontalToID(vertical+1, horizontal), conditions: [noPiece]} )
-            if (horizontal - 1 > 0 && vertical + 1 < 9) output.push( {pos: verticalAndHorizontalToID(vertical+1, horizontal-1), conditions: [notSameType]} )
-            if (horizontal + 1 < 9 && vertical + 1 < 9) output.push( {pos: verticalAndHorizontalToID(vertical+1, horizontal+1), conditions: [notSameType]} )
-        } else {
-            if (vertical - 1 > 0) output.push( {pos: verticalAndHorizontalToID(vertical-1, horizontal), conditions: [noPiece]} )
-            if (horizontal - 1 > 0 && vertical - 1 > 0) output.push( {pos: verticalAndHorizontalToID(vertical-1, horizontal-1), conditions: [notSameType]} )
-            if (horizontal + 1 < 9 && vertical - 1 > 0) output.push( {pos: verticalAndHorizontalToID(vertical-1, horizontal+1), conditions: [notSameType]} )
-        }
-
-        
-
-        return output
-    }
+    static moves = [
+        // sideways
+        { type: 'place', pos: [ 0, -1], conditions: [noPiece] },
+        { type: 'place', pos: [ 0,  1], conditions: [noPiece] },
+        // forward
+        { type: 'place', pos: [ 1,  0], conditions: [noPiece] },
+        // forward + attack
+        { type: 'place', pos: [ 1, -1], conditions: [notSameType] },
+        { type: 'place', pos: [ 1,  1], conditions: [notSameType] },
+    ]
 }

--- a/pieces-js/Piece.js
+++ b/pieces-js/Piece.js
@@ -1,4 +1,5 @@
 import { Position } from "../helper-js/board.js"
+import { MovePreprocessor } from "../helper-js/moves.js";
 
 export class Piece {
     
@@ -16,7 +17,9 @@ export class Piece {
     }
 
     getMoves(){
-        console.error("called piece getMoves")
-        return []
+        if ( ! this.constructor.moves ) {
+            console.error(`[core.Piece] ${this.constructor.name} must provide moves `);
+        }
+        return new MovePreprocessor(this, this.constructor.moves).getMoves();
     }
 }


### PR DESCRIPTION
This PR gives any `Piece` class two options for defining moves:

- Allows the same `getMoves` override to continue to work as before
- For some pieces we can define `static moves` for data-defined moves

I only updated one piece to use this so far - `Fish` because it was the simplest

The following represents `Fish`'s moves:

    static moves = [
        // sideways
        { type: 'place', pos: [ 0, -1], conditions: [noPiece] },
        { type: 'place', pos: [ 0,  1], conditions: [noPiece] },
        // forward
        { type: 'place', pos: [ 1,  0], conditions: [noPiece] },
        // forward + attack
        { type: 'place', pos: [ 1, -1], conditions: [notSameType] },
        { type: 'place', pos: [ 1,  1], conditions: [notSameType] },
    ]

Here's what the definitions mean
- Right now `type: 'place'` is the only type of move, with plans to add `type: 'range'` later.
- For `type: 'place'`, `pos` is a _relative_ position to the piece's position (a vector)
- For black pieces the `pos` vector will be vertically flipped by the preprocessor